### PR TITLE
[JENKINS-60845] Feature: filter PR by branch source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.5
+
+- Add support for filtering tags and branches plus if they're pull requests from
+  a specific origin rather than to a target.
+
 # 0.4 Release (Aug 12th, 2018)
 
 - Add support for filtering for tags.  This adds the ability to have a tag based

--- a/README.md
+++ b/README.md
@@ -20,6 +20,30 @@ plugin refer to the wiki article [SCM Filter Branch PR Plugin][wiki].
 
 For release notes, please refer to the [CHANGELOG.md](CHANGELOG.md).
 
+# How to compile plugin
+
+Developer environment:
+
+    Ubuntu 18.04.3 LTS
+    Linux 5.3.0-26-generic x86_64
+
+    Apache Maven 3.6.0
+    Maven home: /usr/share/maven
+    Java version: 1.8.0_232, vendor: Private Build, runtime: /usr/lib/jvm/java-8-openjdk-amd64/jre
+    Default locale: en_US, platform encoding: UTF-8
+    OS name: "linux", version: "5.3.0-26-generic", arch: "amd64", family: "unix"
+
+    openjdk version "1.8.0_232"
+    OpenJDK Runtime Environment (build 1.8.0_232-8u232-b09-0ubuntu1~18.04.1-b09)
+    OpenJDK 64-Bit Server VM (build 25.232-b09, mixed mode)
+
+To compile the plugin run the following command.
+
+    mvn clean package
+
+Upload the compiled plugin to Jenkins located at
+`target/scm-filter-branch-pr.hpi`.
+
 # License
 
 ```

--- a/src/main/java/net/gleske/scmfilter/impl/trait/RegexSCMOriginFilterTrait.java
+++ b/src/main/java/net/gleske/scmfilter/impl/trait/RegexSCMOriginFilterTrait.java
@@ -1,0 +1,209 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ * Copyright (c) 2017, Sam Gleske - https://github.com/samrocketman
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package net.gleske.scmfilter.impl.trait;
+
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import hudson.util.FormValidation;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+import jenkins.scm.api.SCMHead;
+import jenkins.scm.api.SCMSource;
+import jenkins.scm.api.mixin.ChangeRequestSCMHead;
+import jenkins.scm.api.mixin.TagSCMHead;
+import jenkins.scm.api.trait.SCMHeadPrefilter;
+import jenkins.scm.api.trait.SCMSourceContext;
+import jenkins.scm.api.trait.SCMSourceTrait;
+import jenkins.scm.api.trait.SCMSourceTraitDescriptor;
+import jenkins.scm.impl.trait.Selection;
+import org.jenkinsci.Symbol;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.QueryParameter;
+
+/**
+ * Decorates a {@link SCMSource} with a {@link SCMHeadPrefilter} that excludes {@link SCMHead} instances with names that
+ * do not match a user supplied regular expression.
+ *
+ * @since 2.2.0
+ */
+public class RegexSCMHeadFilterTrait extends SCMSourceTrait {
+
+    /**
+     * The branch regular expression.
+     */
+    @NonNull
+    private final String regex;
+
+    /**
+     * The tag regular expression.
+     */
+    @NonNull
+    private final String tagRegex;
+
+    /**
+     * The compiled branch {@link Pattern}.
+     */
+    @CheckForNull
+    private transient Pattern pattern;
+
+    /**
+     * The compiled tag {@link Pattern}.
+     */
+    @CheckForNull
+    private transient Pattern tagPattern;
+
+    /**
+     * Stapler constructor.
+     *
+     * @param regex the branch regular expression.
+     * @param tagRegex the tag regular expression.
+     */
+    @DataBoundConstructor
+    public RegexSCMHeadFilterTrait(@NonNull String regex, @NonNull String tagRegex) {
+        pattern = Pattern.compile(regex);
+        this.regex = regex;
+        tagPattern = Pattern.compile(tagRegex);
+        this.tagRegex = tagRegex;
+    }
+
+    /**
+     * Deprecated constructor kept around for compatibility and migration.
+     *
+     * @param regex the regular expression.
+     */
+    @Deprecated
+    public RegexSCMHeadFilterTrait(@NonNull String regex) {
+        pattern = Pattern.compile(regex);
+        this.regex = regex;
+        tagPattern = Pattern.compile("(?!.*)");
+        this.tagRegex = "(?!.*)";
+    }
+
+    /**
+     * Gets the branch regular expression.
+     *
+     * @return the branch regular expression.
+     */
+    @NonNull
+    public String getRegex() {
+        return regex;
+    }
+
+    /**
+     * Gets the tag regular expression.
+     *
+     * @return the tag regular expression.
+     */
+    @NonNull
+    public String getTagRegex() {
+        return tagRegex;
+    }
+
+    /**
+     * Gets the compiled branch {@link Pattern}.
+     *
+     * @return the compiled branch {@link Pattern}.
+     */
+    @NonNull
+    private Pattern getPattern() {
+        if (pattern == null) {
+            // idempotent
+            pattern = Pattern.compile(regex);
+        }
+        return pattern;
+    }
+
+    /**
+     * Gets the compiled tag {@link Pattern}.
+     *
+     * @return the compiled tag {@link Pattern}.
+     */
+    @NonNull
+    private Pattern getTagPattern() {
+        if (tagPattern == null) {
+            // idempotent
+            tagPattern = Pattern.compile(tagRegex);
+        }
+        return tagPattern;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected void decorateContext(SCMSourceContext<?, ?> context) {
+        context.withPrefilter(new SCMHeadPrefilter() {
+            @Override
+            public boolean isExcluded(@NonNull SCMSource source, @NonNull SCMHead head) {
+                if (head instanceof ChangeRequestSCMHead) {
+                    head = ((ChangeRequestSCMHead)head).getTarget();
+                }
+
+                if (head instanceof TagSCMHead) {
+                    return !getTagPattern().matcher(head.getName()).matches();
+                } else {
+                    return !getPattern().matcher(head.getName()).matches();
+                }
+            }
+        });
+    }
+
+    /**
+     * Our descriptor.
+     */
+    @Symbol("headRegexFilterWithPR")
+    @Extension
+    @Selection
+    public static class DescriptorImpl extends SCMSourceTraitDescriptor {
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public String getDisplayName() {
+            return Messages.RegexSCMHeadFilterTrait_DisplayName();
+        }
+
+        /**
+         * Form validation for the regular expression.
+         *
+         * @param value the regular expression.
+         * @return the validation results.
+         */
+        @Restricted(NoExternalUse.class) // stapler
+        public FormValidation doCheckRegex(@QueryParameter String value) {
+            try {
+                Pattern.compile(value);
+                return FormValidation.ok();
+            } catch (PatternSyntaxException e) {
+                return FormValidation.error(e.getMessage());
+            }
+        }
+    }
+}

--- a/src/main/java/net/gleske/scmfilter/impl/trait/WildcardSCMOriginFilterTrait.java
+++ b/src/main/java/net/gleske/scmfilter/impl/trait/WildcardSCMOriginFilterTrait.java
@@ -1,0 +1,207 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ * Copyright (c) 2017-2018, Sam Gleske - https://github.com/samrocketman
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package net.gleske.scmfilter.impl.trait;
+
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import java.util.regex.Pattern;
+import jenkins.scm.api.SCMHead;
+import jenkins.scm.api.SCMSource;
+import jenkins.scm.api.mixin.ChangeRequestSCMHead;
+import jenkins.scm.api.mixin.TagSCMHead;
+import jenkins.scm.api.trait.SCMHeadPrefilter;
+import jenkins.scm.api.trait.SCMSourceContext;
+import jenkins.scm.api.trait.SCMSourceTrait;
+import jenkins.scm.api.trait.SCMSourceTraitDescriptor;
+import jenkins.scm.impl.trait.Selection;
+import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/**
+ * Decorates a {@link SCMSource} with a {@link SCMHeadPrefilter} that filters {@link SCMHead} instances based on
+ * matching wildcard include/exclude rules.
+ *
+ * @since 2.2.0
+ */
+public class WildcardSCMHeadFilterTrait extends SCMSourceTrait {
+
+    /**
+     * The branch include rules.
+     */
+    @NonNull
+    private final String includes;
+
+    /**
+     * The branch exclude rules.
+     */
+    @NonNull
+    private final String excludes;
+
+    /**
+     * The tag include rules.
+     */
+    @NonNull
+    private final String tagIncludes;
+
+    /**
+     * The tag exclude rules.
+     */
+    @NonNull
+    private final String tagExcludes;
+
+    /**
+     * Stapler constructor.
+     *
+     * @param includes the branch include rules.
+     * @param excludes the branch exclude rules.
+     * @param tagIncludes the tag include rules.
+     * @param tagExcludes the tag exclude rules.
+     */
+    @DataBoundConstructor
+    public WildcardSCMHeadFilterTrait(@CheckForNull String includes, String excludes, String tagIncludes, String tagExcludes) {
+        this.includes = StringUtils.defaultIfBlank(includes, "*");
+        this.excludes = StringUtils.defaultIfBlank(excludes, "");
+        this.tagIncludes = StringUtils.defaultIfBlank(tagIncludes, "");
+        this.tagExcludes = StringUtils.defaultIfBlank(tagExcludes, "");
+    }
+
+    /**
+     * Deprecated constructor kept around for compatibility and migration.
+     *
+     * @param includes the include rules.
+     * @param excludes the exclude rules.
+     */
+    @Deprecated
+    public WildcardSCMHeadFilterTrait(@CheckForNull String includes, String excludes) {
+        this.includes = StringUtils.defaultIfBlank(includes, "*");
+        this.excludes = StringUtils.defaultIfBlank(excludes, "");
+        this.tagIncludes = "";
+        this.tagExcludes = "*";
+    }
+
+    /**
+     * Returns the branch include rules.
+     *
+     * @return the branch include rules.
+     */
+    public String getIncludes() {
+        return includes;
+    }
+
+    /**
+     * Returns the branch exclude rules.
+     *
+     * @return the branch exclude rules.
+     */
+    public String getExcludes() {
+        return excludes;
+    }
+
+    /**
+     * Returns the tag include rules.
+     *
+     * @return the tag include rules.
+     */
+    public String getTagIncludes() {
+        return tagIncludes;
+    }
+
+    /**
+     * Returns the tag exclude rules.
+     *
+     * @return the tag exclude rules.
+     */
+    public String getTagExcludes() {
+        return tagExcludes;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected void decorateContext(SCMSourceContext<?, ?> context) {
+        context.withPrefilter(new SCMHeadPrefilter() {
+            @Override
+            public boolean isExcluded(@NonNull SCMSource request, @NonNull SCMHead head) {
+                if (head instanceof ChangeRequestSCMHead) {
+                    head = ((ChangeRequestSCMHead)head).getTarget();
+                }
+
+                if(head instanceof TagSCMHead) {
+                    return !Pattern.matches(getPattern(getTagIncludes()), head.getName())
+                         || Pattern.matches(getPattern(getTagExcludes()), head.getName());
+                } else {
+                    return !Pattern.matches(getPattern(getIncludes()), head.getName())
+                         || Pattern.matches(getPattern(getExcludes()), head.getName());
+                }
+            }
+        });
+    }
+
+    /**
+     * Returns the pattern corresponding to the branches containing wildcards.
+     *
+     * @param branches the names of branches to create a pattern for
+     * @return pattern corresponding to the branches containing wildcards
+     */
+    private String getPattern(String branches) {
+        StringBuilder quotedBranches = new StringBuilder();
+        for (String wildcard : branches.split(" ")) {
+            StringBuilder quotedBranch = new StringBuilder();
+            for (String branch : wildcard.split("(?=[*])|(?<=[*])")) {
+                if (branch.equals("*")) {
+                    quotedBranch.append(".*");
+                } else if (!branch.isEmpty()) {
+                    quotedBranch.append(Pattern.quote(branch));
+                }
+            }
+            if (quotedBranches.length() > 0) {
+                quotedBranches.append("|");
+            }
+            quotedBranches.append(quotedBranch);
+        }
+        return quotedBranches.toString();
+    }
+
+    /**
+     * Our descriptor.
+     */
+    @Symbol("headWildcardFilterWithPR")
+    @Extension
+    @Selection
+    public static class DescriptorImpl extends SCMSourceTraitDescriptor {
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public String getDisplayName() {
+            return Messages.WildcardSCMHeadFilterTrait_DisplayName();
+        }
+    }
+}

--- a/src/main/resources/net/gleske/scmfilter/impl/trait/Messages.properties
+++ b/src/main/resources/net/gleske/scmfilter/impl/trait/Messages.properties
@@ -24,3 +24,5 @@
 #
 WildcardSCMHeadFilterTrait.DisplayName=Filter by name including PRs destined for this branch (with wildcards)
 RegexSCMHeadFilterTrait.DisplayName=Filter by name including PRs destined for this branch (with regular expression)
+WildcardSCMOriginFilterTrait.DisplayName=Filter by name including PRs originating from this branch (with wildcards)
+RegexSCMOriginFilterTrait.DisplayName=Filter by name including PRs originating from this branch (with regular expression)

--- a/src/main/resources/net/gleske/scmfilter/impl/trait/RegexSCMOriginFilterTrait/config.jelly
+++ b/src/main/resources/net/gleske/scmfilter/impl/trait/RegexSCMOriginFilterTrait/config.jelly
@@ -1,0 +1,32 @@
+<!--
+ ~ The MIT License
+ ~
+ ~ Copyright (c) 2017, CloudBees, Inc.
+ ~
+ ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+ ~ of this software and associated documentation files (the "Software"), to deal
+ ~ in the Software without restriction, including without limitation the rights
+ ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ ~ copies of the Software, and to permit persons to whom the Software is
+ ~ furnished to do so, subject to the following conditions:
+ ~
+ ~ The above copyright notice and this permission notice shall be included in
+ ~ all copies or substantial portions of the Software.
+ ~
+ ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ ~ THE SOFTWARE.
+ -->
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+  <f:entry title="${%Branch regular expression}" field="regex">
+    <f:textbox default=".*"/>
+  </f:entry>
+  <f:entry title="${%Tag regular expression}" field="tagRegex">
+    <f:textbox default="(?!.*)"/>
+  </f:entry>
+</j:jelly>

--- a/src/main/resources/net/gleske/scmfilter/impl/trait/RegexSCMOriginFilterTrait/help-regex.html
+++ b/src/main/resources/net/gleske/scmfilter/impl/trait/RegexSCMOriginFilterTrait/help-regex.html
@@ -1,0 +1,27 @@
+<!--
+ ~ The MIT License
+ ~
+ ~ Copyright (c) 2017, CloudBees, Inc.
+ ~
+ ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+ ~ of this software and associated documentation files (the "Software"), to deal
+ ~ in the Software without restriction, including without limitation the rights
+ ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ ~ copies of the Software, and to permit persons to whom the Software is
+ ~ furnished to do so, subject to the following conditions:
+ ~
+ ~ The above copyright notice and this permission notice shall be included in
+ ~ all copies or substantial portions of the Software.
+ ~
+ ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ ~ THE SOFTWARE.
+ -->
+<div>
+    A <a href="https://docs.oracle.com/javase/7/docs/api/java/util/regex/Pattern.html">Java regular expression</a> to
+    restrict the names. Names that do not match the supplied regular expression will be ignored.
+</div>

--- a/src/main/resources/net/gleske/scmfilter/impl/trait/RegexSCMOriginFilterTrait/help-tagRegex.html
+++ b/src/main/resources/net/gleske/scmfilter/impl/trait/RegexSCMOriginFilterTrait/help-tagRegex.html
@@ -1,0 +1,27 @@
+<!--
+ ~ The MIT License
+ ~
+ ~ Copyright (c) 2017-2018, Sam Gleske - https://github.com/samrocketman
+ ~
+ ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+ ~ of this software and associated documentation files (the "Software"), to deal
+ ~ in the Software without restriction, including without limitation the rights
+ ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ ~ copies of the Software, and to permit persons to whom the Software is
+ ~ furnished to do so, subject to the following conditions:
+ ~
+ ~ The above copyright notice and this permission notice shall be included in
+ ~ all copies or substantial portions of the Software.
+ ~
+ ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ ~ THE SOFTWARE.
+ -->
+<div>
+    A <a href="https://docs.oracle.com/javase/7/docs/api/java/util/regex/Pattern.html">Java regular expression</a> to
+    restrict the names. Names for tags that do not match the supplied regular expression will be ignored.
+</div>

--- a/src/main/resources/net/gleske/scmfilter/impl/trait/WildcardSCMOriginFilterTrait/config.jelly
+++ b/src/main/resources/net/gleske/scmfilter/impl/trait/WildcardSCMOriginFilterTrait/config.jelly
@@ -1,0 +1,38 @@
+<!--
+ ~ The MIT License
+ ~
+ ~ Copyright (c) 2017, CloudBees, Inc.
+ ~
+ ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+ ~ of this software and associated documentation files (the "Software"), to deal
+ ~ in the Software without restriction, including without limitation the rights
+ ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ ~ copies of the Software, and to permit persons to whom the Software is
+ ~ furnished to do so, subject to the following conditions:
+ ~
+ ~ The above copyright notice and this permission notice shall be included in
+ ~ all copies or substantial portions of the Software.
+ ~
+ ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ ~ THE SOFTWARE.
+ -->
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+  <f:entry title="${%Branch Include}" field="includes">
+    <f:textbox default="*"/>
+  </f:entry>
+  <f:entry title="${%Branch Exclude}" field="excludes">
+    <f:textbox default=""/>
+  </f:entry>
+  <f:entry title="${%Tag Include}" field="tagIncludes">
+    <f:textbox default=""/>
+  </f:entry>
+  <f:entry title="${%Tag Exclude}" field="tagExcludes">
+    <f:textbox default="*"/>
+  </f:entry>
+</j:jelly>

--- a/src/main/resources/net/gleske/scmfilter/impl/trait/WildcardSCMOriginFilterTrait/help-excludes.html
+++ b/src/main/resources/net/gleske/scmfilter/impl/trait/WildcardSCMOriginFilterTrait/help-excludes.html
@@ -1,0 +1,27 @@
+<!--
+ ~ The MIT License
+ ~
+ ~ Copyright (c) 2017, CloudBees, Inc.
+ ~
+ ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+ ~ of this software and associated documentation files (the "Software"), to deal
+ ~ in the Software without restriction, including without limitation the rights
+ ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ ~ copies of the Software, and to permit persons to whom the Software is
+ ~ furnished to do so, subject to the following conditions:
+ ~
+ ~ The above copyright notice and this permission notice shall be included in
+ ~ all copies or substantial portions of the Software.
+ ~
+ ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ ~ THE SOFTWARE.
+ -->
+<div>
+    Branch name patterns to ignore even if matched by the includes list.
+    For example: <code>release</code>
+</div>

--- a/src/main/resources/net/gleske/scmfilter/impl/trait/WildcardSCMOriginFilterTrait/help-includes.html
+++ b/src/main/resources/net/gleske/scmfilter/impl/trait/WildcardSCMOriginFilterTrait/help-includes.html
@@ -1,0 +1,27 @@
+<!--
+ ~ The MIT License
+ ~
+ ~ Copyright (c) 2017, CloudBees, Inc.
+ ~
+ ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+ ~ of this software and associated documentation files (the "Software"), to deal
+ ~ in the Software without restriction, including without limitation the rights
+ ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ ~ copies of the Software, and to permit persons to whom the Software is
+ ~ furnished to do so, subject to the following conditions:
+ ~
+ ~ The above copyright notice and this permission notice shall be included in
+ ~ all copies or substantial portions of the Software.
+ ~
+ ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ ~ THE SOFTWARE.
+ -->
+<div>
+    Space-separated list of branch name patterns to consider.
+    You may use <code>*</code> as a wildcard; for example: <code>master release*</code>
+</div>

--- a/src/main/resources/net/gleske/scmfilter/impl/trait/WildcardSCMOriginFilterTrait/help-tagExcludes.html
+++ b/src/main/resources/net/gleske/scmfilter/impl/trait/WildcardSCMOriginFilterTrait/help-tagExcludes.html
@@ -1,0 +1,27 @@
+<!--
+ ~ The MIT License
+ ~
+ ~ Copyright (c) 2017-2018, Sam Gleske - https://github.com/samrocketman
+ ~
+ ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+ ~ of this software and associated documentation files (the "Software"), to deal
+ ~ in the Software without restriction, including without limitation the rights
+ ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ ~ copies of the Software, and to permit persons to whom the Software is
+ ~ furnished to do so, subject to the following conditions:
+ ~
+ ~ The above copyright notice and this permission notice shall be included in
+ ~ all copies or substantial portions of the Software.
+ ~
+ ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ ~ THE SOFTWARE.
+ -->
+<div>
+    Tag name patterns to ignore even if matched by the tag includes list.
+    For example: <code>*-0.*</code>
+</div>

--- a/src/main/resources/net/gleske/scmfilter/impl/trait/WildcardSCMOriginFilterTrait/help-tagIncludes.html
+++ b/src/main/resources/net/gleske/scmfilter/impl/trait/WildcardSCMOriginFilterTrait/help-tagIncludes.html
@@ -1,0 +1,28 @@
+<!--
+ ~ The MIT License
+ ~
+ ~ Copyright (c) 2017-2018, Sam Gleske - https://github.com/samrocketman
+ ~
+ ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+ ~ of this software and associated documentation files (the "Software"), to deal
+ ~ in the Software without restriction, including without limitation the rights
+ ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ ~ copies of the Software, and to permit persons to whom the Software is
+ ~ furnished to do so, subject to the following conditions:
+ ~
+ ~ The above copyright notice and this permission notice shall be included in
+ ~ all copies or substantial portions of the Software.
+ ~
+ ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ ~ THE SOFTWARE.
+ -->
+<div>
+    Space-separated list of tag name patterns to consider.
+    You may use <code>*</code> as a wildcard; for example: <code>*-1.*</code>
+    to build only 1.0 tags from the maven release plugin.
+</div>


### PR DESCRIPTION
# New filters

There are two new filters provided by this pull request.  Filtering by branches and by pull requests originating from the name.

As opposed to existing filters, which filter for pull requests destined for the named branch.

# Why new filters?

I evaluated the following.

* Updating existing filters with additional options
* Adding new filters as completely new types.

I decided to go with adding new filters because updating existing filters with more options would break some API compatibility.  It also keeps configuration simpler.

# Screenshot

![Screenshot from 2020-01-25 16-03-56](https://user-images.githubusercontent.com/875669/73127399-9d498080-3f8d-11ea-8e94-c30a157c6985.png)

# See also

- [JENKINS-60845][JENKINS-60845] Filter PR by branch source

[JENKINS-60845]: https://issues.jenkins-ci.org/browse/JENKINS-60845